### PR TITLE
fix projections build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @rbuch
+* @ritvikrao

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @rbuch
 * @ritvikrao

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 15]
+        java: [24]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -75,4 +75,3 @@ tasks.register('copyJarToBin', Copy) {
     into('bin/')
     rename { 'projections.jar' }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,18 @@
-apply plugin: 'java'
-apply plugin: 'application'
+plugins {
+  id 'java'
+  id 'application'
+}
+
+application {
+  mainClass = 'projections.analysis.ProjMain'
+}
+
+java {
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
+}
+
+version = '6.10.0'
 
 repositories {
   mavenCentral()
@@ -17,10 +30,6 @@ dependencies {
   implementation 'org.jfree:jfreechart:1.5.0'
 }
 
-mainClassName = 'projections.analysis.ProjMain'
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-version = '6.10.0'
 
 sourceSets {
   main {
@@ -30,36 +39,40 @@ sourceSets {
   }
 }
 
-task fatJar(type: Jar) {
-  manifest {
-    attributes 'Implementation-Title': 'Projections',
-               'Implementation-Version': project.version
-  }
-  project.archivesBaseName = 'projections-all'
-  duplicatesStrategy = DuplicatesStrategy.INCLUDE
+tasks.register('fatJar', Jar) {
+    archiveBaseName.set('projections-all')
+    archiveVersion.set(project.version.toString())
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
-  from {
-    configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-  }
-
-  into ('projections/images') {
-      from('src/projections/images') {
-          include '*'
-      }
-  }
-
-  into ('META-INF/services/') {
-    from ('src/projections/resources') {
-      include 'org.freehep.graphicsbase.util.export.ExportFileType'
+    manifest {
+        attributes(
+            'Implementation-Title': 'Projections',
+            'Implementation-Version': project.version
+        )
     }
-  }
 
-  with jar
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+
+    into('projections/images') {
+        from('src/projections/images') {
+            include '*'
+        }
+    }
+
+    into('META-INF/services/') {
+        from('src/projections/resources') {
+            include 'org.freehep.graphicsbase.util.export.ExportFileType'
+        }
+    }
+
+    with tasks.jar
 }
 
-task copyJarToBin(type: Copy) {
-  from fatJar
-  into 'bin/'
-  rename 'projections-all-' + version + '.jar', 'projections.jar'
+tasks.register('copyJarToBin', Copy) {
+    from(tasks.named('fatJar'))
+    into('bin/')
+    rename { 'projections.jar' }
 }
 


### PR DESCRIPTION
Due to certain Gradle features being deprecated, these changes are needed to fix the projections build. This is also needed to allow Charm++ PRs to be merged (so that the projections test can pass).